### PR TITLE
Update net-debug images

### DIFF
--- a/helm/stunner-kurento-one2one-call/templates/kurento-deployment.yaml
+++ b/helm/stunner-kurento-one2one-call/templates/kurento-deployment.yaml
@@ -48,7 +48,7 @@ spec:
         - containerPort: {{ .Values.mediaServer.deployment.containerPort }}
 {{- if eq .Values.netdebug "enable"}}
       - name: net-debug
-        image: retvari/net-debug:latest
+        image: l7mp/net-debug:latest
         command: ["/bin/sh"]
         args: ["-c", "while true; do echo hello; sleep 10;done"]
 {{- end}}

--- a/helm/stunner/templates/stunner-deployment.yaml
+++ b/helm/stunner/templates/stunner-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         resources: {{- toYaml .Values.stunner.deployment.container.image.resources | nindent 10 }}
 {{- if eq .Values.stunner.deployment.container.netdebug.enabled true}}
       - name: net-debug
-        image: retvari/net-debug:latest
+        image: l7mp/net-debug:latest
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh"]
         args: ["-c", "while true; do echo hello; sleep 10;done"]


### PR DESCRIPTION
Use [l7mp/net-debug](https://hub.docker.com/r/l7mp/net-debug) images (updated: 4 months ago) instead of [retvari/net-debug](https://hub.docker.com/r/retvari/net-debug) images (updated: 3 years ago).