### PR TITLE
Add `metricsEndpoint` to GatewayConfig CRD

### DIFF
--- a/helm/stunner-gateway-operator/crds/stunner-crd.yaml
+++ b/helm/stunner-gateway-operator/crds/stunner-crd.yaml
@@ -84,6 +84,10 @@ spec:
                   STUNner relay connections.
                 format: int32
                 type: integer
+              metricsEndpoint:
+                description: MetricsEndpoint holds the the URL to the metric server
+                  (Prometheus)
+                type: string
               minPort:
                 description: MinRelayPort is the smallest relay port assigned for
                   STUNner relay connections.


### PR DESCRIPTION
Related to https://github.com/l7mp/stunner-gateway-operator/pull/6