### PR TITLE
Fix: Use a static selector label with stunnerd

### DIFF
--- a/helm/stunner/templates/stunner-deployment.yaml
+++ b/helm/stunner/templates/stunner-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "stunner.labels" . | nindent 6 }}
+      app: stunner
   replicas: {{ .Values.stunner.deployment.replica }}
   template:
     metadata:


### PR DESCRIPTION
Similar to the operator, we need a static selector label for deployment