### PR TITLE
feat(stunner-prometheus): Make node-exporter creation optional

### DIFF
--- a/helm/stunner-prometheus/templates/node-exporter.yaml
+++ b/helm/stunner-prometheus/templates/node-exporter.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nodeExporter.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -177,4 +178,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: node-exporter
----
+{{- end }}

--- a/helm/stunner-prometheus/values.yaml
+++ b/helm/stunner-prometheus/values.yaml
@@ -25,6 +25,12 @@ service:
 rbac:
   create: true
 
+nodeExporter:
+  # Specifies whether node-exporter should be instantiated
+  # Note: node-exporter is not required for monitoring STUNner instances
+  # Note: node-exporter is not compatible with GKE Autopilot clusters
+  create: false
+
 nodePorts:
   prometheus: 30900
   alertmanager: 30903

--- a/helm/stunner-prometheus/values.yaml
+++ b/helm/stunner-prometheus/values.yaml
@@ -9,7 +9,7 @@ namespace: monitoring
 selectorLabels:
   component: controller
   name: prometheus-operator
-  version: v0.58.0
+  version: v0.61.1
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
This PR introduces a new helm value to control creation of node-exporter resources.
Fixes #9 .