### PR TITLE
chore(CI): Add install and upgrade tests

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,7 +23,7 @@ jobs:
           repository: l7mp/stunner-helm
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.3.1
+        uses: helm/chart-testing-action@v2
 
       - name: Run chart-testing (lint)
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,5 @@
-name: Test Helm charts
+name: Lint Helm charts
+
 on:
   workflow_dispatch:
   push:
@@ -11,7 +12,7 @@ on:
 
 
 jobs:
-  test_charts:
+  linter:
     runs-on: ubuntu-latest
     steps:
       - name: stunner-helm checkout
@@ -21,11 +22,6 @@ jobs:
           ref: main
           repository: l7mp/stunner-helm
 
-      - name: Set up Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.11.2
-
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.3.1
 
@@ -33,11 +29,3 @@ jobs:
         run: |
           cd stunner-helm
           ct lint --all --chart-dirs helm --excluded-charts stunner-kurento-one2one-call
-
-      - name: Create kind cluster
-        uses: helm/kind-action@v1.4.0
-
-      - name: Run chart-testing (install)
-        run: |
-          cd stunner-helm
-          ct install --all --chart-dirs helm --excluded-charts stunner-kurento-one2one-call

--- a/.github/workflows/publish-manual.yaml
+++ b/.github/workflows/publish-manual.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.11.2
+          version: v3.11.3
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.3.1

--- a/.github/workflows/publish-manual.yaml
+++ b/.github/workflows/publish-manual.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.10.0
+          version: v3.11.2
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.3.1
@@ -60,6 +60,14 @@ jobs:
         run: |
           cd stunner-helm
           ct lint --all --chart-dirs helm --excluded-charts stunner-kurento-one2one-call
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.4.0
+
+      - name: Run chart-testing (install)
+        run: |
+          cd stunner-helm
+          ct install --all --chart-dirs helm --excluded-charts stunner-kurento-one2one-call
 
       - name: Build helm chart for stunner
         if: ${{ env.TYPE == 'stunner'}}

--- a/.github/workflows/publish-manual.yaml
+++ b/.github/workflows/publish-manual.yaml
@@ -54,7 +54,7 @@ jobs:
           version: v3.11.3
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.3.1
+        uses: helm/chart-testing-action@v2
 
       - name: Run chart-testing (lint)
         run: |
@@ -62,7 +62,7 @@ jobs:
           ct lint --all --chart-dirs helm --excluded-charts stunner-kurento-one2one-call
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.4.0
+        uses: helm/kind-action@v1.5.0
 
       - name: Run chart-testing (install)
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.11.2
+          version: v3.11.3
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.3.1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -53,7 +53,7 @@ jobs:
           version: v3.11.3
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.3.1
+        uses: helm/chart-testing-action@v2
 
       - name: Run chart-testing (lint)
         run: |
@@ -61,7 +61,7 @@ jobs:
           ct lint --all --chart-dirs helm --excluded-charts stunner-kurento-one2one-call
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.4.0
+        uses: helm/kind-action@v1.5.0
 
       - name: Run chart-testing (install)
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,7 @@ on:
         options:
           - stunner
           - stunner-gateway-operator
-      
+
 
 env:
   TAG: ${{ inputs.tag }}
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.10.0
+          version: v3.11.2
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.3.1
@@ -59,6 +59,14 @@ jobs:
         run: |
           cd stunner-helm
           ct lint --all --chart-dirs helm --excluded-charts stunner-kurento-one2one-call
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.4.0
+
+      - name: Run chart-testing (install)
+        run: |
+          cd stunner-helm
+          ct install --all --chart-dirs helm --excluded-charts stunner-kurento-one2one-call
 
       - name: Build helm chart for stunner
         if: ${{ env.TYPE == 'stunner'}}

--- a/.github/workflows/test-upgrade-from-stable-to-dev.yaml
+++ b/.github/workflows/test-upgrade-from-stable-to-dev.yaml
@@ -4,7 +4,7 @@ on:
 
 
 jobs:
-  test_charts:
+  test_upgrade:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Helm

--- a/.github/workflows/test-upgrade-from-stable-to-dev.yaml
+++ b/.github/workflows/test-upgrade-from-stable-to-dev.yaml
@@ -14,7 +14,7 @@ jobs:
           version: v3.11.3
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.4.0
+        uses: helm/kind-action@v1.5.0
 
       - name: Run helm upgrade test
         run: |

--- a/.github/workflows/test-upgrade-from-stable-to-dev.yaml
+++ b/.github/workflows/test-upgrade-from-stable-to-dev.yaml
@@ -1,7 +1,8 @@
 name: Test Helm chart upgrade
 on:
   workflow_dispatch:
-
+  schedule:
+  - cron: '0 11 * * 1'
 
 jobs:
   test_upgrade:

--- a/.github/workflows/test-upgrade-from-stable-to-dev.yaml
+++ b/.github/workflows/test-upgrade-from-stable-to-dev.yaml
@@ -1,0 +1,25 @@
+name: Test Helm chart upgrade
+on:
+  workflow_dispatch:
+
+
+jobs:
+  test_charts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.11.2
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.4.0
+
+      - name: Run helm upgrade test
+        run: |
+          helm repo add stunner https://l7mp.io/stunner
+          helm repo update
+          helm install stunner-gateway-operator stunner/stunner-gateway-operator --create-namespace --namespace=stunner
+          helm install stunner stunner/stunner --create-namespace --namespace=stunner
+          helm upgrade stunner-gateway-operator stunner/stunner-gateway-operator-dev --create-namespace --namespace=stunner
+          helm upgrade stunner stunner/stunner-dev --create-namespace --namespace=stunner

--- a/.github/workflows/test-upgrade-from-stable-to-dev.yaml
+++ b/.github/workflows/test-upgrade-from-stable-to-dev.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.11.2
+          version: v3.11.3
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.4.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,31 @@
+name: Test Helm charts
+on:
+  workflow_dispatch:
+
+
+jobs:
+  test_charts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: stunner-helm checkout
+        uses: actions/checkout@v3
+        with:
+          path: stunner-helm
+          ref: main
+          repository: l7mp/stunner-helm
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.11.2
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.3.1
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.4.0
+
+      - name: Run chart-testing (lint and install)
+        run: |
+          cd stunner-helm
+          ct lint-and-install --all --upgrade --chart-dirs helm --excluded-charts stunner-kurento-one2one-call

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,13 @@
 name: Test Helm charts
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+    branches: [ main ]
 
 
 jobs:
@@ -22,10 +29,15 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.3.1
 
+      - name: Run chart-testing (lint)
+        run: |
+          cd stunner-helm
+          ct lint --all --chart-dirs helm --excluded-charts stunner-kurento-one2one-call
+
       - name: Create kind cluster
         uses: helm/kind-action@v1.4.0
 
-      - name: Run chart-testing (lint and install)
+      - name: Run chart-testing (install)
         run: |
           cd stunner-helm
-          ct lint-and-install --all --upgrade --chart-dirs helm --excluded-charts stunner-kurento-one2one-call
+          ct install --all --chart-dirs helm --excluded-charts stunner-kurento-one2one-call


### PR DESCRIPTION
This PR implements 2 important features:
- introduces a new test action that combines linting and installing helm charts from source on a kind cluster;
- adds an automated upgrade test action that installs and upgrades stunner and stunner-gateway-operator from stable to dev channel on a "real" kind cluster.

TODO? Might be a wise move to integrate test.yaml with existing publish workflows. wdyt? 