### PR TITLE
Add nodeselector and tolerations for stunner-auth-service

### DIFF
--- a/helm/stunner-gateway-operator/Chart.yaml
+++ b/helm/stunner-gateway-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.0
+version: 0.15.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/stunner-gateway-operator/templates/stunner-auth-service.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-auth-service.yaml
@@ -82,6 +82,12 @@ spec:
             requests:
               cpu: 10m
               memory: 64Mi
+      {{- with .Values.stunnerAuthService.deployment.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.stunnerAuthService.deployment.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/helm/stunner-gateway-operator/values.yaml
+++ b/helm/stunner-gateway-operator/values.yaml
@@ -31,3 +31,7 @@ stunnerGatewayOperator:
 
 stunnerAuthService:
   enabled: true
+  deployment:
+    tolerations: []
+    nodeSelector:
+      kubernetes.io/os: linux


### PR DESCRIPTION
**What**
Add configurable node selector and tolerations to gateway operator Helm charts --> stunner-auth-service.yaml.

**Why**

Addition of nodeselector and tolerances parameters for stunner-auth-service to standardize with other charts
