### PR TITLE
Fix missing replicas field in dataplane

### DIFF
--- a/helm/stunner-gateway-operator/templates/stunner-default-dataplane.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-default-dataplane.yaml
@@ -5,6 +5,7 @@ kind: Dataplane
 metadata:
   name: default
 spec:
+  replicas: {{ .replicas }}
   image: {{ .image }}
   imagePullPolicy: {{ .imagePullPolicy }}
   command:


### PR DESCRIPTION
I want to be able to deploy more than a single dataplane replica with the helm chart. This PR should make that possible.

I'm assuming the support exists on the operator side, but this is currently in the `values.yaml` so I assumed it's valid.

If we could get a point release of the helm chart for this that would be amazing, thanks for shipping 0.16.0 we're excited to try out so many of the latest improvements.