### PR TITLE
Add containerSecurityContext to default Dataplane

### DIFF
--- a/helm/stunner-gateway-operator/templates/stunner-default-dataplane.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-default-dataplane.yaml
@@ -29,6 +29,9 @@ spec:
   {{- with .securityContext }}
   securityContext: {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .containerSecurityContext }}
+  containerSecurityContext: {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .tolerations }}
   tolerations: {{- toYaml . | nindent 2 }}
   {{- end }}

--- a/helm/stunner-gateway-operator/values.yaml
+++ b/helm/stunner-gateway-operator/values.yaml
@@ -59,6 +59,7 @@ stunnerGatewayOperator:
       hostNetwork: false
       affinity: {}
       securityContext: {}
+      containerSecurityContext: {}
       tolerations: []
 
 stunnerAuthService:


### PR DESCRIPTION
This PR will add the `containerSecurityContext` to the values.yaml and the default `Dataplane` resource, allowing users who installed STUNner via Helm to make use of the new feature from 0.19.0 release.