### PR TITLE
Add podlabels to stunner-gateway-operator chart

### DIFF
--- a/helm/stunner-gateway-operator/templates/stunner-auth-service.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-auth-service.yaml
@@ -17,6 +17,9 @@ spec:
     metadata:
       labels:
         app: stunner-auth
+        {{- with $.Values.stunnerAuthService.deployment.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       terminationGracePeriodSeconds: 10
       containers:

--- a/helm/stunner-gateway-operator/templates/stunner-gateway-operator.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-gateway-operator.yaml
@@ -317,6 +317,9 @@ spec:
       labels:
         control-plane: stunner-gateway-operator-controller-manager
         stunner.l7mp.io/config-discovery-service: enabled
+        {{- with .Values.stunnerGatewayOperator.deployment.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - args:

--- a/helm/stunner-gateway-operator/values.yaml
+++ b/helm/stunner-gateway-operator/values.yaml
@@ -8,6 +8,7 @@ stunnerGatewayOperator:
   enabled: true
   deployment:
     name: stunner-gateway-operator
+    podLabels: {}
     tolerations: []
     nodeSelector:
       kubernetes.io/os: linux
@@ -64,6 +65,7 @@ stunnerGatewayOperator:
 stunnerAuthService:
   enabled: true
   deployment:
+    podLabels: {}
     tolerations: []
     nodeSelector:
       kubernetes.io/os: linux


### PR DESCRIPTION
This PR adds podlabels to the `stunner-auth` and `stunner-gateway-operator-controller-manager` deployments.