### PR TITLE
feat(gateway-operator): Consistent image settings

### DIFF
--- a/helm/stunner-gateway-operator/templates/stunner-default-dataplane.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-default-dataplane.yaml
@@ -6,8 +6,8 @@ metadata:
   name: default
 spec:
   replicas: {{ .replicas }}
-  image: {{ .image }}
-  imagePullPolicy: {{ .imagePullPolicy }}
+  image: "{{ .image.name }}:{{ .image.tag }}"
+  imagePullPolicy: {{ .image.pullPolicy }}
   command:
     {{- range .command }}
     - {{ . }}

--- a/helm/stunner-gateway-operator/templates/stunner-gateway-operator.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-gateway-operator.yaml
@@ -324,7 +324,8 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0
-        image: {{ .Values.stunnerGatewayOperator.deployment.container.kubeRbacProxy.image.name }}
+        image: "{{ .Values.stunnerGatewayOperator.deployment.container.kubeRbacProxy.image.name }}:{{ .Values.stunnerGatewayOperator.deployment.container.kubeRbacProxy.image.tag }}"
+        imagePullPolicy: {{ .Values.stunnerGatewayOperator.deployment.container.kubeRbacProxy.image.pullPolicy }}
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/helm/stunner-gateway-operator/values.yaml
+++ b/helm/stunner-gateway-operator/values.yaml
@@ -31,7 +31,9 @@ stunnerGatewayOperator:
           - --zap-log-level=info
       kubeRbacProxy:
         image:
-          name: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+          name: gcr.io/kubebuilder/kube-rbac-proxy
+          pullPolicy: IfNotPresent
+          tag: v0.11.0
   dataplane:
     # Can be 'legacy' or 'managed'
     # default is managed
@@ -39,8 +41,10 @@ stunnerGatewayOperator:
     spec:
       replicas: 1
       # for dev version set it to l7mp/stunnerd:dev
-      image: docker.io/l7mp/stunnerd:0.19.0
-      imagePullPolicy: Always
+      image:
+        name: docker.io/l7mp/stunnerd
+        pullPolicy: Always
+        tag: 0.19.0
       command:
         - stunnerd
       args:


### PR DESCRIPTION
In the chart for the gateway-operator the image settings were inconsistent, which I would like to bring to a form with this PR.
My main motivation was to be able to overwrite the image registry, but not have to change the image tag with every update. So far this was only possible with the operator image itself. Now it is also possible with the rbac proxy and the stunnerd image.