### PR TITLE
feat(stunner-gateway-operator): Option to add labels and annotations to the default Dataplane

### DIFF
--- a/helm/stunner-gateway-operator/templates/stunner-default-dataplane.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-default-dataplane.yaml
@@ -23,6 +23,12 @@ spec:
   terminationGracePeriodSeconds: {{ .terminationGracePeriodSeconds }}
   enableMetricsEndpoint: {{ .enableMetricsEndpoint }}
   hostNetwork: {{ .hostNetwork }}
+  {{- with .labels }}
+  labels: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .affinity }}
   affinity: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/helm/stunner-gateway-operator/values.yaml
+++ b/helm/stunner-gateway-operator/values.yaml
@@ -60,6 +60,8 @@ stunnerGatewayOperator:
       terminationGracePeriodSeconds: 3600
       enableMetricsEndpoint: false
       hostNetwork: false
+      labels: {}
+      annotations: {}
       affinity: {}
       securityContext: {}
       tolerations: []


### PR DESCRIPTION
Based on the discussion, I have created a PR that allows users to set custom labels and annotations for the default Dataplane using the Helm chart and therefore set them for the stunnerd pods.