### PR TITLE
refact(gateway-operator): Fix  inconsistent image settings

### DIFF
--- a/.github/workflows/publish-manual.yaml
+++ b/.github/workflows/publish-manual.yaml
@@ -54,15 +54,16 @@ jobs:
           cd stunner-helm/helm
           if ${{ env.TAG == 'dev' }}; then
             sed -ri 's/^(\s*)(name\s*:\s*.*\s*$)/\1name: stunner-gateway-operator-dev/' stunner-gateway-operator/Chart.yaml
-            sed -ri 's/^(\s*)(          pullPolicy\s*:\s*.*\s*$)/\1          pullPolicy: Always/' stunner-gateway-operator/values.yaml
-            sed -ri 's|^(\s*)(      image: docker.io/l7mp/stunnerd:\s*.*\s*$)|      image: docker.io/l7mp/stunnerd:dev|' stunner-gateway-operator/values.yaml
-            sed -ri 's|^(\s*)(          tag\s*:\s*.*\s*$)|          tag: dev|' stunner-gateway-operator/values.yaml
+            sed -i '/stunnerGatewayOperator:/,/pullPolicy:/ s/\(pullPolicy:\s*\).*/\1Always/' stunner-gateway-operator/values.yaml
+            sed -i '/dataplane:/,/pullPolicy:/ s/\(pullPolicy:\s*\).*/\1Always/' stunner-gateway-operator/values.yaml
+            sed -i '/dataplane:/,/tag:/ s/\(tag:\s*\).*/\1'"dev"'/' stunner-gateway-operator/values.yaml
+            sed -i '/authService:/,/pullPolicy:/ s/\(pullPolicy:\s*\).*/\1Always/' stunner-gateway-operator/values.yaml
+            sed -i '/authService:/,/tag:/ s/\(tag:\s*\).*/\1'"dev"'/' stunner-gateway-operator/values.yaml
           else
             sed -ri 's/^(\s*)(version\s*:\s*.*\s*$)/\1version: ${{ env.TAG }}/' stunner-gateway-operator/Chart.yaml
-            sed -ri 's|^(\s*)(      image: docker.io/l7mp/stunnerd:\s*.*\s*$)|      image: docker.io/l7mp/stunnerd:${{ env.TAG }}|' stunner-gateway-operator/values.yaml
           fi
+          sed -i '/stunnerGatewayOperator:/,/tag:/ s/\(tag:\s*\).*/\1'"${{ env.TAG }}"'/' stunner-gateway-operator/values.yaml
           sed -ri 's/^(\s*)(appVersion\s*:\s*.*\s*$)/\1appVersion: ${{ env.TAG }}/' stunner-gateway-operator/Chart.yaml
-          sed -ri 's/^(\s*)(          tag\s*:\s*.*\s*$)/\1          tag: ${{ env.TAG }}/' stunner-gateway-operator/values.yaml
 
       - name: Set up Helm
         uses: azure/setup-helm@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -53,15 +53,16 @@ jobs:
           cd stunner-helm/helm
           if ${{ env.TAG == 'dev' }}; then
             sed -ri 's/^(\s*)(name\s*:\s*.*\s*$)/\1name: stunner-gateway-operator-dev/' stunner-gateway-operator/Chart.yaml
-            sed -ri 's/^(\s*)(          pullPolicy\s*:\s*.*\s*$)/\1          pullPolicy: Always/' stunner-gateway-operator/values.yaml
-            sed -ri 's|^(\s*)(      image: docker.io/l7mp/stunnerd:\s*.*\s*$)|      image: docker.io/l7mp/stunnerd:dev|' stunner-gateway-operator/values.yaml
-            sed -ri 's|^(\s*)(          tag\s*:\s*.*\s*$)|          tag: dev|' stunner-gateway-operator/values.yaml
+            sed -i '/stunnerGatewayOperator:/,/pullPolicy:/ s/\(pullPolicy:\s*\).*/\1Always/' stunner-gateway-operator/values.yaml
+            sed -i '/dataplane:/,/pullPolicy:/ s/\(pullPolicy:\s*\).*/\1Always/' stunner-gateway-operator/values.yaml
+            sed -i '/dataplane:/,/tag:/ s/\(tag:\s*\).*/\1'"dev"'/' stunner-gateway-operator/values.yaml
+            sed -i '/authService:/,/pullPolicy:/ s/\(pullPolicy:\s*\).*/\1Always/' stunner-gateway-operator/values.yaml
+            sed -i '/authService:/,/tag:/ s/\(tag:\s*\).*/\1'"dev"'/' stunner-gateway-operator/values.yaml
           else
             sed -ri 's/^(\s*)(version\s*:\s*.*\s*$)/\1version: ${{ env.TAG }}/' stunner-gateway-operator/Chart.yaml
-            sed -ri 's|^(\s*)(      image: docker.io/l7mp/stunnerd:\s*.*\s*$)|      image: docker.io/l7mp/stunnerd:${{ env.TAG }}|' stunner-gateway-operator/values.yaml
           fi
+          sed -i '/stunnerGatewayOperator:/,/tag:/ s/\(tag:\s*\).*/\1'"${{ env.TAG }}"'/' stunner-gateway-operator/values.yaml
           sed -ri 's/^(\s*)(appVersion\s*:\s*.*\s*$)/\1appVersion: ${{ env.TAG }}/' stunner-gateway-operator/Chart.yaml
-          sed -ri 's/^(\s*)(          tag\s*:\s*.*\s*$)/\1          tag: ${{ env.TAG }}/' stunner-gateway-operator/values.yaml
 
       - name: Set up Helm
         uses: azure/setup-helm@v4

--- a/helm/stunner-gateway-operator/templates/stunner-default-dataplane.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-default-dataplane.yaml
@@ -6,8 +6,8 @@ metadata:
   name: default
 spec:
   replicas: {{ .replicas }}
-  image: {{ .image }}
-  imagePullPolicy: {{ .imagePullPolicy }}
+  image: "{{ .image.name }}:{{ .image.tag }}"
+  imagePullPolicy: {{ .image.pullPolicy }}
   command:
     {{- range .command }}
     - {{ . }}

--- a/helm/stunner-gateway-operator/templates/stunner-gateway-operator.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-gateway-operator.yaml
@@ -327,7 +327,8 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0
-        image: {{ .Values.stunnerGatewayOperator.deployment.container.kubeRbacProxy.image.name }}
+        image: "{{ .Values.stunnerGatewayOperator.deployment.container.kubeRbacProxy.image.name }}:{{ .Values.stunnerGatewayOperator.deployment.container.kubeRbacProxy.image.tag }}"
+        imagePullPolicy: {{ .Values.stunnerGatewayOperator.deployment.container.kubeRbacProxy.image.pullPolicy }}
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/helm/stunner-gateway-operator/values.yaml
+++ b/helm/stunner-gateway-operator/values.yaml
@@ -34,7 +34,9 @@ stunnerGatewayOperator:
           - --zap-log-level=info
       kubeRbacProxy:
         image:
-          name: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+          name: gcr.io/kubebuilder/kube-rbac-proxy
+          pullPolicy: IfNotPresent
+          tag: v0.16.0
   dataplane:
     # Can be 'legacy' or 'managed'
     # default is managed
@@ -42,8 +44,10 @@ stunnerGatewayOperator:
     spec:
       replicas: 1
       # for dev version set it to docker.io/l7mp/stunnerd:dev
-      image: docker.io/l7mp/stunnerd:0.21.0
-      imagePullPolicy: IfNotPresent
+      image:
+        name: docker.io/l7mp/stunnerd
+        pullPolicy: IfNotPresent
+        tag: 0.21.0
       command:
         - stunnerd
       args:


### PR DESCRIPTION
This PR aims to fix and improve the proposed issues in PR #31. The publish workflows had to be changed accordingly. The `sed` commands are now more _precise_ to prevent accidental overwrites in case there are keys with the same indentation depth.

I was worried this might be a breaking change; however, I don't see anything that would cause trouble with these changes. 

Please check @levaitamas  @rg0now 