### PR TITLE
Add configurable replicas to stunner-auth template

### DIFF
--- a/helm/stunner-gateway-operator/templates/stunner-auth-service.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-auth-service.yaml
@@ -12,7 +12,9 @@ spec:
   selector:
     matchLabels:
       app: stunner-auth
-  replicas: 1
+  {{- if .deployment.replicas }}
+  replicas: {{ .deployment.replicas }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/helm/stunner-gateway-operator/templates/stunner-auth-service.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-auth-service.yaml
@@ -12,9 +12,7 @@ spec:
   selector:
     matchLabels:
       app: stunner-auth
-  {{- if .deployment.replicas }}
   replicas: {{ .deployment.replicas }}
-  {{- end }}
   template:
     metadata:
       labels:

--- a/helm/stunner-gateway-operator/values.yaml
+++ b/helm/stunner-gateway-operator/values.yaml
@@ -75,10 +75,11 @@ stunnerAuthService:
   deployment:
     podLabels: {}
     tolerations: []
+    # replicas: 3
     nodeSelector:
       kubernetes.io/os: linux
     imagePullSecrets:
-#      - name: docker-registry-secret
+    #  - name: docker-registry-secret
     container:
       authService:
         image:

--- a/helm/stunner-gateway-operator/values.yaml
+++ b/helm/stunner-gateway-operator/values.yaml
@@ -75,7 +75,7 @@ stunnerAuthService:
   deployment:
     podLabels: {}
     tolerations: []
-    # replicas: 3
+    replicas: 1
     nodeSelector:
       kubernetes.io/os: linux
     imagePullSecrets:


### PR DESCRIPTION
Closes #39.

I've made two changes actually. First, the default behavior will be to not specify replicas at all. This is pretty much the same as `replicas: 1` but it has the added benefit that you can use autoscaling and not have tools like ArgoCD or Flux fight with the autoscaling since from their perspective replicas is not managed by the IaC tools.

Second, replicas is now configurable via `values.yaml`. Any number specified is set as expected.

Replicas is intentionally left commented out in `values.yaml` to prevent any potential autoscaling from interfering in the default case.

I've tested this locally via `helm template` and verified it functions as described above.