### PR TITLE
Support imagePullSecrets for Dataplane

### DIFF
--- a/helm/stunner-gateway-operator/templates/stunner-default-dataplane.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-default-dataplane.yaml
@@ -8,6 +8,9 @@ spec:
   replicas: {{ .replicas }}
   image: "{{ .image.name }}:{{ .image.tag }}"
   imagePullPolicy: {{ .image.pullPolicy }}
+  {{- if .imagePullSecrets }}
+  imagePullSecrets: {{- toYaml .imagePullSecrets | nindent 4 }}
+  {{- end }}
   command:
     {{- range .command }}
     - {{ . }}

--- a/helm/stunner-gateway-operator/values.yaml
+++ b/helm/stunner-gateway-operator/values.yaml
@@ -49,7 +49,7 @@ stunnerGatewayOperator:
         pullPolicy: IfNotPresent
         tag: 1.0.0
       imagePullSecrets:
-        - name: image-pull-secret
+        # - name: docker-registry-secret
       command:
         - stunnerd
       args:

--- a/helm/stunner-gateway-operator/values.yaml
+++ b/helm/stunner-gateway-operator/values.yaml
@@ -48,6 +48,8 @@ stunnerGatewayOperator:
         name: docker.io/l7mp/stunnerd
         pullPolicy: IfNotPresent
         tag: 1.0.0
+      imagePullSecrets:
+        - name: image-pull-secret
       command:
         - stunnerd
       args:


### PR DESCRIPTION
Currently, it seems imagePullSecrets is supported by the Dataplane [here](https://github.com/l7mp/stunner-gateway-operator/blob/6d98845b6a2529127fcba2207d694f58c8ff4526/api/v1/dataplane_types.go#L70). However, the chart doesn't currently support specifying this field. I've verified myself that the field in Dataplane does work as intended by patching manually.