### PR TITLE
various securityContext-related fixes

### DIFF
--- a/helm/stunner-gateway-operator/templates/stunner-auth-service.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-auth-service.yaml
@@ -35,7 +35,6 @@ spec:
           {{- with .deployment.container.authService.securityContext }}
           securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- end }}
           resources: {{- toYaml .deployment.container.authService.resources | nindent 12 }}
       nodeSelector: {{- toYaml .deployment.nodeSelector | nindent 8 }}
       tolerations: {{- toYaml .deployment.tolerations | nindent 8 }}

--- a/helm/stunner-gateway-operator/templates/stunner-auth-service.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-auth-service.yaml
@@ -32,8 +32,9 @@ spec:
           {{- range $.Values.stunnerAuthService.deployment.container.authService.args }}
           - {{ . }}
           {{- end }}
-          {{- with $.Values.stunnerAuthService.deployment.container.authService.securityContext }}
+          {{- with .deployment.container.authService.securityContext }}
           securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- end }}
           resources: {{- toYaml .deployment.container.authService.resources | nindent 12 }}
       nodeSelector: {{- toYaml .deployment.nodeSelector | nindent 8 }}

--- a/helm/stunner-gateway-operator/templates/stunner-auth-service.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-auth-service.yaml
@@ -30,7 +30,7 @@ spec:
           args:
           - --cds-server-address=stunner-config-discovery.{{ $.Values.namespace | default $.Release.Namespace }}.svc
           {{- range $.Values.stunnerAuthService.deployment.container.authService.args }}
-          -  {{ . }}
+          - {{ . }}
           {{- end }}
           {{- with $.Values.stunnerAuthService.deployment.container.authService.securityContext }}
           securityContext: {{- toYaml . | nindent 16 }}

--- a/helm/stunner-gateway-operator/templates/stunner-auth-service.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-auth-service.yaml
@@ -32,11 +32,9 @@ spec:
           {{- range $.Values.stunnerAuthService.deployment.container.authService.args }}
           -  {{ . }}
           {{- end }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - "ALL"
+          {{- with $.Values.stunnerAuthService.deployment.container.authService.securityContext }}
+          securityContext: {{- toYaml . | nindent 16 }}
+          {{- end }}
           resources: {{- toYaml .deployment.container.authService.resources | nindent 12 }}
       nodeSelector: {{- toYaml .deployment.nodeSelector | nindent 8 }}
       tolerations: {{- toYaml .deployment.tolerations | nindent 8 }}

--- a/helm/stunner-gateway-operator/templates/stunner-auth-service.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-auth-service.yaml
@@ -33,7 +33,7 @@ spec:
           - {{ . }}
           {{- end }}
           {{- with $.Values.stunnerAuthService.deployment.container.authService.securityContext }}
-          securityContext: {{- toYaml . | nindent 16 }}
+          securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
           resources: {{- toYaml .deployment.container.authService.resources | nindent 12 }}
       nodeSelector: {{- toYaml .deployment.nodeSelector | nindent 8 }}

--- a/helm/stunner-gateway-operator/templates/stunner-default-dataplane.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-default-dataplane.yaml
@@ -32,6 +32,9 @@ spec:
   {{- with .affinity }}
   affinity: {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .containerSecurityContext }}
+  containerSecurityContext: {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .securityContext }}
   securityContext: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/helm/stunner-gateway-operator/values.yaml
+++ b/helm/stunner-gateway-operator/values.yaml
@@ -81,6 +81,11 @@ stunnerAuthService:
 #      - name: docker-registry-secret
     container:
       authService:
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - "ALL"
         image:
           name: docker.io/l7mp/stunner-auth-server
           pullPolicy: IfNotPresent

--- a/helm/stunner-gateway-operator/values.yaml
+++ b/helm/stunner-gateway-operator/values.yaml
@@ -67,6 +67,7 @@ stunnerGatewayOperator:
       labels: {}
       annotations: {}
       affinity: {}
+      containerSecurityContext: {}
       securityContext: {}
       tolerations: []
 

--- a/helm/stunner-gateway-operator/values.yaml
+++ b/helm/stunner-gateway-operator/values.yaml
@@ -83,10 +83,7 @@ stunnerAuthService:
     container:
       authService:
         securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - "ALL"
+          runAsNonRoot: true
         image:
           name: docker.io/l7mp/stunner-auth-server
           pullPolicy: IfNotPresent


### PR DESCRIPTION
My cluster enables the [Pod Security admission controller](https://kubernetes.io/docs/concepts/security/pod-security-admission/), which requires every pod to adhere to [pod security standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/):

```
W1201 09:34:55.535139   14754 warnings.go:70] would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "stunner-auth-server" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "stunner-auth-server" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "stunner-auth-server" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "stunner-auth-server" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

This PR allows chart consumers to set the `securityContext` of some resources to values that adhere to those standards. The original values are kept as defaults.
