### PR TITLE
kube-rbac-proxy and manager container securityContext exposure

### DIFF
--- a/helm/stunner-gateway-operator/templates/stunner-gateway-operator.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-gateway-operator.yaml
@@ -341,6 +341,7 @@ spec:
           requests:
             cpu: 5m
             memory: 64Mi
+        securityContext: {{- toYaml .Values.stunnerGatewayOperator.deployment.container.kubeRbacProxy.securityContext | nindent 10 }}
       - args:
         {{- range $.Values.stunnerGatewayOperator.deployment.container.manager.args }}
         -  {{ . }}
@@ -382,8 +383,7 @@ spec:
         - containerPort: 13478
           name: cds
           protocol: TCP
-        securityContext:
-          allowPrivilegeEscalation: false
+        securityContext: {{- toYaml .Values.stunnerGatewayOperator.deployment.container.manager.securityContext | nindent 10 }}
       securityContext:
         runAsNonRoot: true
       serviceAccountName: stunner-gateway-operator-controller-manager

--- a/helm/stunner-gateway-operator/values.yaml
+++ b/helm/stunner-gateway-operator/values.yaml
@@ -32,11 +32,14 @@ stunnerGatewayOperator:
           - --metrics-bind-address=127.0.0.1:8080
           - --leader-elect
           - --zap-log-level=info
+        securityContext:
+          allowPrivilegeEscalation: false
       kubeRbacProxy:
         image:
           name: gcr.io/kubebuilder/kube-rbac-proxy
           pullPolicy: IfNotPresent
           tag: v0.16.0
+        securityContext: {}
   dataplane:
     # Can be 'legacy' or 'managed'
     # default is managed


### PR DESCRIPTION
This is a follow-up to https://github.com/l7mp/stunner-helm/pull/42.