### PR TITLE
ISSUE-49: Add resource parameterization for kube-rbac-proxy

### DIFF
--- a/helm/stunner-gateway-operator/templates/stunner-gateway-operator.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-gateway-operator.yaml
@@ -321,13 +321,7 @@ spec:
         - containerPort: 8443
           name: https
           protocol: TCP
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
+        resources: {{- toYaml .Values.stunnerGatewayOperator.deployment.container.kubeRbacProxy.resources | nindent 10 }}
         securityContext: {{- toYaml .Values.stunnerGatewayOperator.deployment.container.kubeRbacProxy.securityContext | nindent 10 }}
       - args:
         {{- range $.Values.stunnerGatewayOperator.deployment.container.manager.args }}

--- a/helm/stunner-gateway-operator/values.yaml
+++ b/helm/stunner-gateway-operator/values.yaml
@@ -43,6 +43,14 @@ stunnerGatewayOperator:
           pullPolicy: IfNotPresent
           tag: v0.16.0
         securityContext: {}
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+
   dataplane:
     # Can be 'legacy' or 'managed'
     # default is managed


### PR DESCRIPTION
The purpose of this Pull Request is to provide a fix by enabling resource parameterization for the kube-rbac-proxy container in the stunner-gateway-operator-controller-manager deployment. See https://github.com/l7mp/stunner-helm/issues/49 for details