### PR TITLE
Additional options for gateway operator

### DIFF
--- a/helm/stunner-gateway-operator/README.md
+++ b/helm/stunner-gateway-operator/README.md
@@ -29,8 +29,10 @@ And that's all: you don't need to install the dataplane separately, this is hand
 | `stunnerGatewayOperator.deployment.name`                                        | Name of the deployment for the operator.                         | `stunner-gateway-operator`                |
 | `stunnerGatewayOperator.deployment.podLabels`                                   | Labels for the deployment pods.                                  | `{}`                                      |
 | `stunnerGatewayOperator.deployment.tolerations`                                 | Tolerations for pod assignment.                                  | `[]`                                      |
+| `stunnerGatewayOperator.deployment.replicas`                                    | Number of replicas of the operator to be deployed.               | `1`                                       |
 | `stunnerGatewayOperator.deployment.nodeSelector`                                | Node labels for pod assignment.                                  | `{}`                                      |
 | `stunnerGatewayOperator.deployment.imagePullSecrets`                            | Image pull secrets for the image.                                | `[]`                                      |
+| `stunnerGatewayOperator.deployment.topologySpreadConstraints`                   | Constraints to control how pods are spread across the cluster.   | `[]`                                      |
 | `stunnerGatewayOperator.deployment.container`                                   | Container configuration values.                                  |                                           |
 | `stunnerGatewayOperator.deployment.container.manager`                           | Configuration values for the STUNner Gateway Operator container. |                                           |
 | `stunnerGatewayOperator.deployment.container.manager.image.name`                | The name of the image to use.                                    | `docker.io/l7mp/stunner-gateway-operator` |
@@ -70,25 +72,27 @@ Default dataplane configuration for the operator to use. See more [here](https:/
 | `stunnerGatewayOperator.dataplane.spec.securityContext`               | Security context for the deployed stunner instance.                                                                                                  | `{}`                      |
 | `stunnerGatewayOperator.dataplane.spec.containerSecurityContext`      | Security context for the container.                                                                                                                  | `{}`                      |
 | `stunnerGatewayOperator.dataplane.spec.tolerations`                   | Tolerations for pod assignment.                                                                                                                      | `[]`                      |
+| `stunnerGatewayOperator.dataplane.spec.topologySpreadConstraints`     | Constraints to control how pods are spread across the cluster.                                                                                       | `[]`                      |
 
 ### STUNner Authentication Service
 
 Default configuration for the authentication service to be deployed. See more the authentication in STUNner [here](https://github.com/l7mp/stunner/blob/main/docs/AUTH.md).
 
-| Name                                                                            | Description                                              | Value                                |
-| ------------------------------------------------------------------------------- | -------------------------------------------------------- | ------------------------------------ |
-| `stunnerAuthService.enabled`                                                    | If enabled, the authentication service will be deployed. | `true`                               |
-| `stunnerAuthService.deployment.podLabels`                                       | Labels for the auth service pods.                        | `{}`                                 |
-| `stunnerAuthService.deployment.tolerations`                                     | Tolerations for pod assignment.                          | `[]`                                 |
-| `stunnerAuthService.deployment.replicas`                                        | Replicas for the auth-service deployment.                | `1`                                  |
-| `stunnerAuthService.deployment.nodeSelector`                                    | Node labels for pod assignment.                          |                                      |
-| `stunnerAuthService.deployment.imagePullSecrets`                                | Image pull secrets for the auth service image.           | `[]`                                 |
-| `stunnerAuthService.deployment.container.authService.securityContext`           | Security context for the auth-service pod.               | `{}`                                 |
-| `stunnerAuthService.deployment.container.authService.image.name`                | The name of the image to use.                            | `docker.io/l7mp/stunner-auth-server` |
-| `stunnerAuthService.deployment.container.authService.image.pullPolicy`          | The pull policy for the image.                           | `IfNotPresent`                       |
-| `stunnerAuthService.deployment.container.authService.image.tag`                 | The tag for the image.                                   | `1.0.0`                              |
-| `stunnerAuthService.deployment.container.authService.resources.limits.cpu`      | CPU limits for the container.                            | `200m`                               |
-| `stunnerAuthService.deployment.container.authService.resources.limits.memory`   | Memory limits for the container.                         | `128Mi`                              |
-| `stunnerAuthService.deployment.container.authService.resources.requests.cpu`    | CPU requests for the container.                          | `10m`                                |
-| `stunnerAuthService.deployment.container.authService.resources.requests.memory` | Memory requests for the container.                       | `64Mi`                               |
-| `stunnerAuthService.deployment.container.authService.args`                      | Arguments for the container.                             | `[]`                                 |
+| Name                                                                            | Description                                                     | Value                                |
+| ------------------------------------------------------------------------------- | ----------------------------------------------------------------| ------------------------------------ |
+| `stunnerAuthService.enabled`                                                    | If enabled, the authentication service will be deployed.        | `true`                               |
+| `stunnerAuthService.deployment.podLabels`                                       | Labels for the auth service pods.                               | `{}`                                 |
+| `stunnerAuthService.deployment.tolerations`                                     | Tolerations for pod assignment.                                 | `[]`                                 |
+| `stunnerAuthService.deployment.replicas`                                        | Replicas for the auth-service deployment.                       | `1`                                  |
+| `stunnerAuthService.deployment.nodeSelector`                                    | Node labels for pod assignment.                                 |                                      |
+| `stunnerAuthService.deployment.imagePullSecrets`                                | Image pull secrets for the auth service image.                  | `[]`                                 |
+| `stunnerAuthService.deployment.topologySpreadConstraints`                       | Constraints to control how pods are spread across the cluster.  | `[]`                                 |
+| `stunnerAuthService.deployment.container.authService.securityContext`           | Security context for the auth-service pod.                      | `{}`                                 |
+| `stunnerAuthService.deployment.container.authService.image.name`                | The name of the image to use.                                   | `docker.io/l7mp/stunner-auth-server` |
+| `stunnerAuthService.deployment.container.authService.image.pullPolicy`          | The pull policy for the image.                                  | `IfNotPresent`                       |
+| `stunnerAuthService.deployment.container.authService.image.tag`                 | The tag for the image.                                          | `1.0.0`                              |
+| `stunnerAuthService.deployment.container.authService.resources.limits.cpu`      | CPU limits for the container.                                   | `200m`                               |
+| `stunnerAuthService.deployment.container.authService.resources.limits.memory`   | Memory limits for the container.                                | `128Mi`                              |
+| `stunnerAuthService.deployment.container.authService.resources.requests.cpu`    | CPU requests for the container.                                 | `10m`                                |
+| `stunnerAuthService.deployment.container.authService.resources.requests.memory` | Memory requests for the container.                              | `64Mi`                               |
+| `stunnerAuthService.deployment.container.authService.args`                      | Arguments for the container.                                    | `[]`                                 |

--- a/helm/stunner-gateway-operator/templates/stunner-auth-service.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-auth-service.yaml
@@ -46,7 +46,12 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
----
+      {{- if $.Values.stunnerAuthService.deployment.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- with $.Values.stunnerAuthService.deployment.topologySpreadConstraints }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/stunner-gateway-operator/templates/stunner-auth-service.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-auth-service.yaml
@@ -52,6 +52,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/stunner-gateway-operator/templates/stunner-default-dataplane.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-default-dataplane.yaml
@@ -44,5 +44,8 @@ spec:
   {{- with .tolerations }}
   tolerations: {{- toYaml . | nindent 2 }}
   {{- end }}
+  {{- if .topologySpreadConstraints }}
+  topologySpreadConstraints: {{- toYaml .topologySpreadConstraints | nindent 4 }}
+  {{- end }}
 {{- end -}}
 {{- end -}}

--- a/helm/stunner-gateway-operator/templates/stunner-gateway-operator.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-gateway-operator.yaml
@@ -295,7 +295,7 @@ metadata:
   name: stunner-gateway-operator-controller-manager
   namespace: {{ $.Values.namespace | default $.Release.Namespace }}
 spec:
-  replicas: 1
+  replicas: {{ $.Values.stunnerGatewayOperator.deployment.replicas }}
   selector:
     matchLabels:
       control-plane: stunner-gateway-operator-controller-manager
@@ -378,3 +378,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.stunnerGatewayOperator.deployment.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- with .Values.stunnerGatewayOperator.deployment.topologySpreadConstraints }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+

--- a/helm/stunner-gateway-operator/templates/stunner-gateway-operator.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-gateway-operator.yaml
@@ -378,9 +378,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.stunnerGatewayOperator.deployment.topologySpreadConstraints }}
+      {{- if $.Values.stunnerGatewayOperator.deployment.topologySpreadConstraints }}
       topologySpreadConstraints:
-        {{- with .Values.stunnerGatewayOperator.deployment.topologySpreadConstraints }}
+        {{- with $.Values.stunnerGatewayOperator.deployment.topologySpreadConstraints }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}

--- a/helm/stunner-gateway-operator/values.yaml
+++ b/helm/stunner-gateway-operator/values.yaml
@@ -12,6 +12,7 @@ stunnerGatewayOperator:
     podLabels: {}
     podAnnotations: {}
     tolerations: []
+    replicas: 1
     nodeSelector:
       kubernetes.io/os: linux
     imagePullSecrets:
@@ -38,6 +39,7 @@ stunnerGatewayOperator:
           - --zap-log-level=info
         securityContext:
           allowPrivilegeEscalation: false
+    topologySpreadConstraints: []
   dataplane:
     # Can be 'legacy' or 'managed'
     # default is managed
@@ -103,3 +105,4 @@ stunnerAuthService:
         args:
           - --port=8088
           - -v
+    topologySpreadConstraints: {}

--- a/helm/stunner-gateway-operator/values.yaml
+++ b/helm/stunner-gateway-operator/values.yaml
@@ -105,4 +105,4 @@ stunnerAuthService:
         args:
           - --port=8088
           - -v
-    topologySpreadConstraints: {}
+    topologySpreadConstraints: []

--- a/helm/stunner-gateway-operator/values.yaml
+++ b/helm/stunner-gateway-operator/values.yaml
@@ -75,6 +75,7 @@ stunnerGatewayOperator:
       containerSecurityContext: {}
       securityContext: {}
       tolerations: []
+      topologySpreadConstraints: []
 
 stunnerAuthService:
   enabled: true


### PR DESCRIPTION
**Summary**
Adds additional options to configure the gateway operator

`replicas` self explanatory, allows adding additional replicas, if desired, to take advantage of leader election for high availability.

`topologySpreadConstraints` see https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ i am using this to spread the backup replicas across nodes / availability zones, so a single node failure doesn't bring down all the backup replicas as well.

For example in EKS https://docs.aws.amazon.com/prescriptive-guidance/latest/ha-resiliency-amazon-eks-apps/spread-workloads.html

I exposed `topologySpreadConstraints` to the `stunner-auth` and the `dataplane` as well

**Testing**
I'm deploying a fork of this chart in my environment and it looks to be working as expected


 