### PR TITLE
optional CRD installation via helm values

### DIFF
--- a/helm/stunner-gateway-operator/templates/crds/gateway-api-crd.yaml
+++ b/helm/stunner-gateway-operator/templates/crds/gateway-api-crd.yaml
@@ -15,6 +15,7 @@
 #
 # Gateway API Experimental channel install
 #
+{{ if and .Values.crds.enabled .Values.crds.gatewayApi }}
 ---
 #
 # config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -15211,3 +15212,4 @@ status:
   conditions: null
   storedVersions: null
 ---
+{{ end }}

--- a/helm/stunner-gateway-operator/templates/crds/stunner-crd.yaml
+++ b/helm/stunner-gateway-operator/templates/crds/stunner-crd.yaml
@@ -1,3 +1,4 @@
+{{ if and .Values.crds.enabled .Values.crds.stunner }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -4608,3 +4609,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{ end }}

--- a/helm/stunner-gateway-operator/values.yaml
+++ b/helm/stunner-gateway-operator/values.yaml
@@ -4,6 +4,11 @@
 # additional commands when installing your release
 # It will create the desired namespace if not present
 
+crds:
+  enabled: true
+  gatewayApi: true
+  stunner: true
+
 stunnerGatewayOperator:
   enabled: true
   customerKey: ""


### PR DESCRIPTION
with this change Helm values control the (now optional) installation of CRDs.

now it is possible to install `stunner-gateway-operator` when gateway api CRDs are already installed through another gateway-api deplyoment or from the upstream gateway-api repository directly.

### this is a breaking change
ive moved CRDs from `helm/stunner-gateway-operator/crds` to `helm/stunner-gateway-operator/templates/crds`
this is necessary to enable helm template while applying those resources.

with that change `--skip-crds`  does not have any effect anymore because Helm itself does not thread them as CRDs internally.
but it enables more granular control over which CRDs are installed via values.

to do so i introduced those new default values to configure CRDs installation:
```yaml
crds:
  enabled: true
  gatewayApi: true
  stunner: true
```

users who used to set `--skip-crds` now need to replace that with `--set crds.enabled=false`
to install `stunner-gateway-operator` alongside preexisting gateway-api CRDs `--set crds.gatewayApi=false` is sufficent.


fixes: #63

greetings,
Kariton
