### PR TITLE
Use service hostname instead of pod IP as operator address.

### DIFF
--- a/helm/stunner-gateway-operator/templates/stunner-gateway-operator.yaml
+++ b/helm/stunner-gateway-operator/templates/stunner-gateway-operator.yaml
@@ -323,10 +323,7 @@ spec:
         - /manager
         env:
         - name: STUNNER_GATEWAY_OPERATOR_ADDRESS
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
+          value: stunner-config-discovery.{{ $.Values.namespace | default $.Release.Namespace }}.svc
         {{- if ne .Values.stunnerGatewayOperator.customerKey "" }}
         - name: CUSTOMER_KEY
           valueFrom:


### PR DESCRIPTION
This fixes an error that prevents the operator from running at all in IPv6 or dual-stack (IPv6-first) clusters. I checked thru the code of the operator and stunner to make sure that it doesn't cause any unforeseen issues, and I've been running the chart with this change in my cluster for some time now.

One possible issue might be if one is running multiple replicas of the operator, but I believe that should be solved by only pointing the service at the pod which is currently acting as the leader, which would require changes to the operator.

But the stunner-auth service already uses this Service to discover configuration, which I assume means that is not a concern.